### PR TITLE
Update Jenkinsfile to support VeriStand 2017-2020

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2017', '2018', '2019']
+List<String> lvVersions = ['2017', '2018', '2019', '2020']
 
 List<String> dependencies = ['niveristand-custom-device-message-library']
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update Jenkinsfile to support VeriStand 2017-2020.

### Why should this Pull Request be merged?

This enables the Routing and Faulting Custom Device to build for VeriStand 2020.

### What testing has been done?

Successfully ran the build pipeline on the branch.
