### PR TITLE
Update build label for new server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,5 @@ List<String> lvVersions = ['2017', '2018', '2019', '2020']
 
 List<String> dependencies = ['niveristand-custom-device-message-library']
 
-ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions, dependencies)
+ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses new build node label for NIJENKINS server

### Why should this Pull Request be merged?

Builds will try to use wrong nodes with old label.

### What testing has been done?

Ran replay
