### PR TITLE
Replace references to master branch with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/CONTRIBUTING.md).
+- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/CONTRIBUTING.md).
 
-TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/CONTRIBUTING.md).
+TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/CONTRIBUTING.md).
 
 ### What does this Pull Request accomplish?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,5 @@ using the `RunVITester` operation provided by the [testing tools](https://github
 
 (taken from [developercertificate.org](https://developercertificate.org/))
 
-See [LICENSE](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/LICENSE)
+See [LICENSE](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/LICENSE)
 for details about how niveristand-slsc-switch-message-library is licensed.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replace references to the `master` branch with `main`.

### Why should this Pull Request be merged?

We renamed the primary branch from `master` to `main`.

### What testing has been done?

N/A
